### PR TITLE
Probably not an error, but...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apk add --no-cache bash
 RUN apk add --no-cache --virtual=build-dependencies curl && \
     curl -sL "http://dl.bintray.com/sbt/native-packages/sbt/$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
     ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
-    chmod 0755 usr/local/bin/sbt && \
+    chmod 0755 /usr/local/bin/sbt && \
     apk del build-dependencies


### PR DESCRIPTION
It actually errored in my version, and it's better to just use the whole path. 